### PR TITLE
make redirect faster by including map in site

### DIFF
--- a/404.md
+++ b/404.md
@@ -21,5 +21,3 @@ Try searching the whole site for the content you want:
     target.nextElementSibling.href = google + site + " " + query;
   };
 </script>
-
-<script src="redirect.js"></script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,4 +1,5 @@
 <head>
+  <script src="redirect.js"></script>
   {% include analytics.html %}
   <title>
     {{ site.title }}{% if page.title %} - {% endif %}{{ page.title }}

--- a/redirect.js
+++ b/redirect.js
@@ -1,15 +1,20 @@
-// on 404, redirect if path matches any entry in redirects tsv map
-const list =
-  "https://storage.googleapis.com/tislab-redirects/tislab.org-redirects.tsv";
-const redirect = async () => {
-  const tsv = await (await fetch(list)).text();
-  const rows = tsv.split("\n").map((line) => line.split("\t"));
-  const path = window.location.pathname.slice(1);
-  const match = rows.find(([from]) => from === path);
-  if (!match) return;
-  const [from, to] = match;
+// on 404, redirect if path matches any entry in redirects list
+
+const tsv =
+  "bWVsem9vbQlodHRwczovL3VjZGVudmVyLnpvb20udXMvai82NDIzMzUyNDE0P3B3ZD1UMFJDVkZFek9VWktaSEpHY2taSGNFeFBWRnBtZHowOQpqdWx6b29tCWh0dHBzOi8vdWNkZW52ZXIuem9vbS51cy9qLzI2NjI3NDUxODI/cHdkPVV6VTFWMFp4YlZaWVdHMTZhaTlIVDBKSU9EZFdaejA5Cm5pY29sZXpvb20JaHR0cHM6Ly91Y2RlbnZlci56b29tLnVzL3MvMjI5NzA2Nzc1OD9wd2Q9U25GeU1raEpXR1pYWlZCb1FXcDRVVUU1T1hneFFUMDk=";
+
+const map = Object.fromEntries(
+  window
+    .atob(tsv)
+    .split("\n")
+    .map((line) => line.split(/\s/).filter((column) => column))
+    .filter((line) => line)
+);
+
+const from = window.location.pathname.slice(1);
+const to = map[from];
+
+if (from && to) {
   console.log(`Redirecting from ${from} to ${to}`);
   window.location.href = to;
-};
-
-redirect();
+}


### PR DESCRIPTION
- puts list on the page (in the repo) itself, removing the delay caused by fetching it from an external url
- puts redirect in `<head>` meaning it should be fully executed before the page shows (before any paint) \*
- [base64 encodes](https://developer.mozilla.org/en-US/docs/Glossary/Base64) list in code to obfuscate \*\*

\* Note that the way I did this, the redirect will happen on any page, not just the 404. So if you ever make a page called `melz***`,  you'll see it go to the redirect. In other words, the redirect takes precedence over the existence of a page with the same name.

\*\* To make changes, you'll need to decode, edit, then reencode. This can be done in any browser's developer console or in online tools. Should I put instructions in the code's comments, or will this just encourage malicious people and you guys can figure it out without comments.