### PR TITLE
Move redirects after analytics

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,6 +1,6 @@
 <head>
-  <script src="redirect.js?v={{ 'now' | date: '%Y-%m-%d-%H-%M' }}"></script>
   {% include analytics.html %}
+  <script src="redirect.js?v={{ 'now' | date: '%Y-%m-%d-%H-%M' }}"></script>
   {% include meta.html %}
   {% include favicons.html %}
   {% include fonts.html %}


### PR DESCRIPTION
The TISLab wishes to track how often certain redirects are landed-on by users.

This PR move's the redirect script to after the analytics script. Hopefully this will allow Google Analytics to track what page the user landed on, before immediately redirecting them to the target url.

https://github.com/tis-lab/tislab.org/blob/main/_includes/analytics.html

This should not cause much if any delay of the redirect, because hopefully the gtag (Google Analytics) script is not doing too much intensive synchronous processing that would block it. The only question is if gtag will reliably be able capture all the data it needs (url, user IP/location, etc) before the redirect script immediately navigates away and thus stops executing all javascript on the page. Hopefully gtag gets all the stuff it needs immediately and synchronously, and then immediately sends a request to the Google Analytics servers to log the info. That way, the request doesn't necessarily need to complete before the redirect happens, it just needs to be initiated.

@falquaddoomi do you have any insight here? I can't find any clear documentation on how the gtag script works.

---

I have checked that:

- [x] all pages' content, images, and styles still appear correctly
- [x] all links still work
- [x] redirects (e.g `deploy-preview-XX--tislab-website.netlify.app/melzoom`) are still working
