### PR TITLE
OSU College of Ag was referenced still somehow

### DIFF
--- a/index.md
+++ b/index.md
@@ -41,7 +41,7 @@ It brings together people and their data across extremely diverse disciplinary d
 - Accelerate Cancer Research
 - Promote Healthy Lifestyles
 
-This means that the research done in TISLab depends upon partnership and collaboration, across multiple disciplines both within the College of Agricultural Sciences and in other areas such as the Office of Institutional Diversity and the Chief Technology Office.
+This means that the research done in TISLab depends upon partnership and collaboration across multiple disciplines.
 
 {% include link.html link="research" text="Learn More" style="button" %}
 {:.center}


### PR DESCRIPTION
Updated the last sentence so it does not mention College of Agricultural Sciences, Office of Diversity and Office of Chief of Technology.

I have checked that:

- [ ] all pages' content, images, and styles still appear correctly
- [ ] all links still work
- [ ] redirects (e.g `deploy-preview-XX--tislab-website.netlify.app/melzoom`) are still working
