### PR TITLE
Update Move the environmental health sciences vocabulary section to "past research" index.md

### DIFF
--- a/research/index.md
+++ b/research/index.md
@@ -181,16 +181,16 @@ Learn more at the [CD2H N3C page](https://covid.cd2h.org/).
 
 {% include section.html %}
 
+# <i class="fas fa-microscope"></i>Past Research
+
+{% include section.html %}
+
 ### Environmental Health Sciences Vocabulary
 
 TISLab is laying the foundation for a new community-driven effort to build data standards for the environmental health sciences.
 
 **Contact:** [Anne Thessen](mailto:annethessen@gmail.com)  
 **Funding:** NIEHS
-
-{% include section.html %}
-
-# <i class="fas fa-microscope"></i>Past Research
 
 {% include section.html %}
 


### PR DESCRIPTION
I have checked that:

- [ ] all pages' content, images, and styles still appear correctly
- [ ] all links still work
- [ ] redirects (e.g `deploy-preview-XX--tislab-website.netlify.app/melzoom`) are still working

https://github.com/tis-lab/tislab.org/issues/79